### PR TITLE
feat: stop shrinking of small type on larger viewports (#21)

### DIFF
--- a/src/generic/_generic.ms-custom-properties.scss
+++ b/src/generic/_generic.ms-custom-properties.scss
@@ -17,8 +17,13 @@
             @if (unit($key) == "px") {
                 @media screen and (min-width: $key) {
                     @each $scale in map-get($FLUIDMS-CONFIG, scales) {
-                        --ms#{$scale}-ratio:       #{fluidms-pow(map-get($value, ratio), $scale)};
-                        --ms#{$scale}-line-height: #{fluidms-line-height($scale, map-get($value, ratio))};
+                        // Exclude all the scales that are smaller than the
+                        // base font-size, so that small type will not get
+                        // smaller on larger viewports (#21).
+                        @if not (str-index(#{$scale}, "-")) {
+                            --ms#{$scale}-ratio:       #{fluidms-pow(map-get($value, ratio), $scale)};
+                            --ms#{$scale}-line-height: #{fluidms-line-height($scale, map-get($value, ratio))};
+                        }
                     }
                 }
             }

--- a/test/style.css
+++ b/test/style.css
@@ -41,13 +41,7 @@
       --ms1-ratio:       1.2;
       --ms1-line-height: 1.75rem;
       --ms0-ratio:       1;
-      --ms0-line-height: 1.5rem;
-      --ms-1-ratio:       0.83333;
-      --ms-1-line-height: 1.25rem;
-      --ms-2-ratio:       0.69444;
-      --ms-2-line-height: 1rem;
-      --ms-3-ratio:       0.5787;
-      --ms-3-line-height: 0.75rem; } }
+      --ms0-line-height: 1.5rem; } }
   @media screen and (min-width: 1280px) {
     :root {
       --ms6-ratio:       4.82681;
@@ -63,13 +57,7 @@
       --ms1-ratio:       1.3;
       --ms1-line-height: 1.75rem;
       --ms0-ratio:       1;
-      --ms0-line-height: 1.5rem;
-      --ms-1-ratio:       0.76923;
-      --ms-1-line-height: 1rem;
-      --ms-2-ratio:       0.59172;
-      --ms-2-line-height: 0.75rem;
-      --ms-3-ratio:       0.45517;
-      --ms-3-line-height: 0.5rem; } }
+      --ms0-line-height: 1.5rem; } }
 
 /*------------------------------------*\
     #PAGE

--- a/test/style.scss
+++ b/test/style.scss
@@ -24,8 +24,6 @@ html {
     );
 }
 
-$h1-font-size: ms(6) !default;
-
 h1 {
     @include fluidms-font-size(
         $font-size: ms(6)


### PR DESCRIPTION
because:
- when the font-size ratio is increased on larger viewports,
the large type gets larger, but the small type is getting
smaller, which is not what we want

this commit:
- stops the shrinking of smaller type (i.e. smaller than the base
font-size) on larger viewports (when the ratio is changed), by not 
generating the respective custom properties for larger viewport 
(media-queries).